### PR TITLE
Fix x._pred.png outfile name bug

### DIFF
--- a/make_output_unet_cmd.py
+++ b/make_output_unet_cmd.py
@@ -100,8 +100,10 @@ try:
         print(f"PROGRESS: {ii}/{nfiles}")
         fname = fname.strip()
         
-        # change file extension to png
-        newfname_class = '.'.join(os.path.basename(fname).split('.')[:-1]) + '_pred.png'
+        # remove input directory from filepath string
+        newfname_class = os.path.split(fname)[-1]
+        # change file extension to '_pred.png'
+        newfname_class = os.path.splitext(newfname_class)[0] + '_pred.png'
         # combine with outdir
         newfname_class = os.path.join(OUTPUT_DIR, newfname_class)
 

--- a/make_output_unet_cmd.py
+++ b/make_output_unet_cmd.py
@@ -99,7 +99,11 @@ try:
     for ii,fname in enumerate(files):
         print(f"PROGRESS: {ii}/{nfiles}")
         fname = fname.strip()
-        newfname_class = "%s/%s_pred.png" % (OUTPUT_DIR, os.path.basename(fname)[0:-4])
+        
+        # change file extension to png
+        newfname_class = '.'.join(os.path.basename(fname).split('.')[:-1]) + '_pred.png'
+        # combine with outdir
+        newfname_class = os.path.join(OUTPUT_DIR, newfname_class)
 
         print(f"working on file: \t {fname}", flush=True)
         print(f"saving to : \t {newfname_class}", flush=True)


### PR DESCRIPTION
The current code at line 102 trims 4 characters from the end of the filename (i.e. '.png') and adds '_pred.png'. This rigid filename trim is inconvenient when using '.tiff' files or any other with extensions longer than 4 characters total, resulting in extra '.' - i.e. 'outfile._pred.png' . The proposed fix introduces dynamic extension trimming, removing any extension after the final '.' in a filename and adding '_pred.png'.