### PR TITLE
Map location set to device in baseline model load

### DIFF
--- a/train_model.py
+++ b/train_model.py
@@ -166,7 +166,8 @@ try:
     # retrieve device from config.ini file
     device = get_torch_device(args.gpuid)
     # map baseline model to desired device
-    checkpoint = torch.load(args.model, map_location = device)
+    checkpoint = torch.load(args.model, map_location=lambda storage, loc: storage) #load checkpoint 
+    # to CPU and then put to device; allows devices to differ between checkpoints 
 
     # +
     model = UNet(n_classes=checkpoint["n_classes"], in_channels=checkpoint["in_channels"],

--- a/train_model.py
+++ b/train_model.py
@@ -163,9 +163,10 @@ try:
     os.makedirs(newmodeldir, exist_ok=True)
 
     # ---- get model setup
-    checkpoint = torch.load(args.model)
-
+    # retrieve device from config.ini file
     device = get_torch_device(args.gpuid)
+    # map baseline model to desired device
+    checkpoint = torch.load(args.model, map_location = device)
 
     # +
     model = UNet(n_classes=checkpoint["n_classes"], in_channels=checkpoint["in_channels"],


### PR DESCRIPTION
I use my QA projects across devices and a problem encountered was deserialization if the GPU/device used for creating the baseline model was different to the device used for further training from baseline. 
Specifically, where I had trained baseline on a device with multiple GPUs and was retraining on a laptop with a single GPU.  The error message encountered was identical to the one outlined here: https://stackoverflow.com/questions/56369030/runtimeerror-attempting-to-deserialize-object-on-a-cuda-device  where users of PyTorch attempted to retrain models using CPU instead of GPU. In my case, I had used GPU ID 1 in a multiGPU system for baseline training and was trying to use GPU 0 in retraining on a single GPU system. All other software (conda env, Ubuntu 20.04, NVidia drivers etc.) was identical between systems. Changing GPU ID in the config.ini file was not sufficient to resolve the error. 
The PyTorch deserialization error was traced to line 169 of this file (train_model.py) in the STDERROR, corresponding with the torch.load() line. As outlined in the above stackoverflow, the solution is through unambiguous assignment of the device to load the model to, using the map_location argument of the PyTorch load() function. By retrieving the device variable one line earlier and unambiguously mapping to the desired device using the map_location argument in line 169, this error was resolved with no other changes in behaviour.