### PR TITLE
Annotations lists correctly reflect onscreen annotations.

### DIFF
--- a/quickannotator/populate_db.ipynb
+++ b/quickannotator/populate_db.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "initial_id",
    "metadata": {
     "ExecuteTime": {
@@ -10,17 +10,7 @@
      "start_time": "2024-11-08T14:35:06.944945Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/opt/QuickAnnotator/venv/lib/python3.8/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-      "  from .autonotebook import tqdm as notebook_tqdm\n",
-      "2024-12-13 15:02:12,467\tINFO util.py:154 -- Missing packages: ['ipywidgets']. Run `pip install -U ipywidgets`, then restart the notebook server for rich notebook output.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from geoalchemy2 import Geometry, load_spatialite\n",
     "from flask_caching import Cache\n",
@@ -48,7 +38,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "bca4dff6768ff12f",
    "metadata": {
     "ExecuteTime": {
@@ -75,7 +65,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "209fd4ac277bf06c",
    "metadata": {
     "ExecuteTime": {
@@ -375,7 +365,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "6c470570e9995f60",
    "metadata": {
     "ExecuteTime": {
@@ -383,16 +373,7 @@
      "start_time": "2024-11-08T14:35:07.667888Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/tmp/ipykernel_71267/1324745128.py:104: SAWarning: Table 'annotation' already exists within the given MetaData - not copying.\n",
-      "  table = Annotation.__table__.to_metadata(db.metadata, name=table_name)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "models = [Project, Image, AnnotationClass, Notification, Tile, Setting]\n",
     "with app.app_context():\n",
@@ -413,7 +394,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "a2bb8615",
    "metadata": {},
    "outputs": [],
@@ -489,7 +470,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "c41c4ce245fc68d2",
    "metadata": {
     "ExecuteTime": {
@@ -497,15 +478,7 @@
      "start_time": "2024-11-08T14:41:40.323315Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 88605/88605 [00:06<00:00, 13469.13it/s]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "insert_existing_annotations(app, db,\n",
     "                            image_id=1,\n",


### PR DESCRIPTION
Resolves issue #50 

This implementation differs from the implementation suggested in the above issue.

For each on-screen tile, behavior is split based on whether the tile has already been rendered.
1. If already rendered, get annotations directly from the viewport
2. Else, get annotations from the backend

Either way, the tile's annotations are concatenated with the full set of annotations, and the respective component state array (`gts` or `preds`) is updated. The updated state causes the annotationList components to update their data.