### PR TITLE
improvements to stitch together the landing, project, annotation use cases

### DIFF
--- a/quickannotator/__main__.py
+++ b/quickannotator/__main__.py
@@ -8,6 +8,7 @@ from quickannotator.config import config
 from quickannotator.config import get_database_uri, get_database_path, get_ray_dashboard_host, get_ray_dashboard_port, get_api_version
 import ray
 from quickannotator.db import init_db, db_session
+from quickannotator.db.crud.annotation_class import insert_tissue_mask_class
 from quickannotator.db.logging import init_logger
 
 def serve_quickannotator(app):
@@ -52,6 +53,7 @@ def main():
             shutil.rmtree(db_path)
 
     init_db()
+    insert_tissue_mask_class() # Consider adding a seed_database method if the database setup gets complicated.
 
     @app.teardown_appcontext
     def shutdown_session(exception=None):

--- a/quickannotator/api/v1/image/models.py
+++ b/quickannotator/api/v1/image/models.py
@@ -13,8 +13,12 @@ class ImageRespSchema(SQLAlchemyAutoSchema):
 
 class GetImageArgsSchema(Schema):
     image_id = fields.Int(required=True)
+
+
 class UploadFileSchema(Schema):
     name = fields.Str(required=True)
+
+
 class SearchImageArgsSchema(Schema):
     pass
 
@@ -29,7 +33,6 @@ class DeleteImageArgsSchema(GetImageArgsSchema):
     pass
 
 class UploadFileArgsSchema(Schema):
-    file = Upload(required=True)
     project_id = fields.Int(required=True)
 
 class ImageMetadataRespSchema(Schema):

--- a/quickannotator/client/src/components/imageTable/imageTable.tsx
+++ b/quickannotator/client/src/components/imageTable/imageTable.tsx
@@ -68,7 +68,7 @@ export default class ImageTable extends React.PureComponent {
     defineGrid() {
         const thumbnailFormatter = (row: number, cell: number, value: any, columnDef: Column, dataContext: any) => {
 
-            return `<a target="_blank" href="..${getAnnotationPageURL(this.props.project.id,value)}"><img src='..${getImageThumbnailURL(value)}' height='64'></img></a>`
+            return `<a href="..${getAnnotationPageURL(this.props.project.id,value)}"><img src='..${getImageThumbnailURL(value)}' height='64'></img></a>`
         }
         const actionFormatter = (row: number, cell: number, value: any, columnDef: Column, dataContext: any) => {
             console.log(dataContext)

--- a/quickannotator/client/src/components/navigation.tsx
+++ b/quickannotator/client/src/components/navigation.tsx
@@ -6,6 +6,7 @@ import Nav from 'react-bootstrap/Nav';
 import NavItem from 'react-bootstrap/NavItem';
 import Container from "react-bootstrap/Container";
 import ProgressBar from "react-bootstrap/ProgressBar"
+import { CaretRightFill } from 'react-bootstrap-icons';
 
 interface NavbarProps {
     currentProject: Project | null;
@@ -19,7 +20,7 @@ const Item = ({ children }) => {
     return (
         <>
             <NavItem style={{alignItems: "center", display: "flex"}}>
-                <i className="bi bi-caret-right-fill text-white"></i>
+                <CaretRightFill className="text-white" />
             </NavItem>
             {children}
         </>

--- a/quickannotator/client/src/components/projectTable/projectTable.tsx
+++ b/quickannotator/client/src/components/projectTable/projectTable.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { Column, GridOption, SlickgridReactInstance, SlickgridReact } from "slickgrid-react";
-import { Modal, Container, Row, Col, Card, ButtonToolbar, ButtonGroup, Button, ListGroup } from "react-bootstrap";
+import { Modal, Container, Row, Col, Card, ButtonToolbar, ButtonGroup, Button, ListGroup, Nav } from "react-bootstrap";
 
 import '@slickgrid-universal/common/dist/styles/css/slickgrid-theme-bootstrap.css';
 import { Project } from "../../types.ts";
+import { Link } from 'react-router-dom';
 
 interface Props {
     projects: Project[];
@@ -79,7 +80,7 @@ export default class ProjectTable extends React.PureComponent {
         }
         const nameFormatter = (row: number, cell: number, value: any, columnDef: Column, dataContext: any) => {
 
-            return `<a target="_blank" href="./project/${dataContext.id}">${value}</a>`
+            return `<a href="/project/${dataContext.id}">${value}</a>`
         }
 
         const columns: Column[] = [

--- a/quickannotator/client/src/routes/landingPage.tsx
+++ b/quickannotator/client/src/routes/landingPage.tsx
@@ -121,7 +121,7 @@ const LandingPage = () => {
                 </Row>
                 <Row className="d-flex flex-grow-1">
                     <Col className="d-flex flex-grow-1"><Card className="flex-grow-1">
-                        <Card.Body>
+                        <Card.Body id="project_table">
                             <ProjectTable containerId='project_table' projects={projects} deleteHandle={showDeleteModalHandle} editHandle={showConfigModalHandle} />
                         </Card.Body>
                     </Card></Col>

--- a/quickannotator/client/src/routes/landingPage.tsx
+++ b/quickannotator/client/src/routes/landingPage.tsx
@@ -1,5 +1,7 @@
 
 import {useState, useEffect } from "react";
+import {Link, useOutletContext} from 'react-router-dom';
+import { OutletContextType } from "../types.ts";
 import { Plus, PencilSquare, Trash } from 'react-bootstrap-icons';
 import { Alert, Container, Row, Col, Card, ButtonToolbar, ButtonGroup, Button } from "react-bootstrap";
 import ProjectTable from '../components/projectTable/projectTable.tsx';
@@ -11,7 +13,7 @@ import {PROJECT_MODAL_STATUS} from '../helpers/config.ts'
 const LandingPage = () => {
     // 0 - create, 1 - update, 2 - remove 
     const [modalStatus, setModalStatus] = useState<PROJECT_MODAL_STATUS.CREATE | PROJECT_MODAL_STATUS.REMOVE | PROJECT_MODAL_STATUS.UPDATE | undefined>(undefined)
-
+    const { setCurrentImage, setCurrentProject } = useOutletContext<OutletContextType>();
     const [projects, setProjects] = useState<Project[]>([])
     const [showAlert, setShowAlert] = useState<boolean>(false)
     const [deletedId, setDeletedId] = useState<number | undefined>(undefined)
@@ -27,6 +29,11 @@ const LandingPage = () => {
 
         });
     }, [])
+
+    useEffect(() => {
+        setCurrentProject(null)
+        setCurrentImage(null);
+    }, []);
 
     const reloadProjects = () => {
         fetchAllProjects().then((resp) => {

--- a/quickannotator/client/src/routes/projectPage.tsx
+++ b/quickannotator/client/src/routes/projectPage.tsx
@@ -13,13 +13,14 @@ import ExportAnnotationsModal from '../components/exportAnnotationsModal/exportA
 
 const ProjectPage = () => {
     const { projectid } = useParams();
-    const { currentProject, setCurrentProject } = useOutletContext<OutletContextType>();
+    const { currentProject, setCurrentProject, currentImage, setCurrentImage } = useOutletContext<OutletContextType>();
     const [images, setImages] = useState<Image[]>([])
     const [settingShow, setSettingShow] = useState<boolean>(false)
     const [embeddingShow, setEmbeddingShow] = useState<boolean>(false)
     const [exportAnnotationsShow, setExportAnnotationsShow] = useState<boolean>(false)
 
     useEffect(() => {
+        setCurrentImage(null);
         if (projectid) {
             fetchProject(parseInt(projectid)).then((resp) => {
                 if (resp.status === 200) {

--- a/quickannotator/constants.py
+++ b/quickannotator/constants.py
@@ -35,13 +35,15 @@ MASK_DILATION = 1
 BASE_PATH = '/opt/QuickAnnotator'
 MOUNTS_PATH = os.path.join(BASE_PATH, 'quickannotator/mounts')
 
-MASK_CLASS_ID = 1
 
 TILE_PRED_EXPIRE = 1 # minutes
 
 MAX_ACTORS_PROCESSING = 1   # TODO: app setting
 
 FLASK_DATETIME_FORMAT = 'iso'
+
+
+COLOR_PALETTE_NAME = 'default'  # TODO: project setting
 
 ANNOTATION_CLASS_COLOR_PALETTES = {
     # https://informatics-isi-edu.github.io/atlas-d2k-docs/docs/color-palette-for-image-annotation/
@@ -56,6 +58,12 @@ ANNOTATION_CLASS_COLOR_PALETTES = {
     ]
 }
 
+MASK_CLASS_ID = 1
+MASK_CLASS_NAME = "Tissue Mask"
+MASK_CLASS_COLOR_IDX = 0
+MASK_CLASS_WORK_MAG = 1.25
+MASK_CLASS_WORK_TILESIZE = 2048
+
 # TODO: move to project settings
 MAGNIFICATION_OPTIONS = [1.25, 2.5, 5.0, 10.0, 20.0, 40.0]  
 
@@ -68,3 +76,8 @@ IMPORT_ANNOTATION_BATCH_SIZE= 1000
 class AnnotationFileFormats(enum.Enum):
     JSON = 'json'
     GEOJSON = 'geojson'
+
+
+class Dialects(enum.Enum):
+    SQLITE = "sqlite"
+    POSTGRESQL = "postgresql"

--- a/quickannotator/db/crud/annotation.py
+++ b/quickannotator/db/crud/annotation.py
@@ -105,10 +105,11 @@ class AnnotationStore:
         self.scaling_factor = 1.0 if in_work_mag else base_to_work_scaling_factor(image_id, annotation_class_id)
 
         table_name = build_annotation_table_name(image_id, annotation_class_id, is_gt=is_gt)
-        if table_exists(table_name):
-            self.model = create_dynamic_model(table_name)
-        else:
+        model = create_dynamic_model(table_name)
+        if model is None:
             self.model = self.create_annotation_table(image_id, annotation_class_id, is_gt)
+        else:
+            self.model = model
 
 
         self.query = get_annotation_query(self.model, 1/self.scaling_factor)
@@ -362,6 +363,10 @@ def build_annotation_table_name(image_id: int, annotation_class_id: int, is_gt: 
 
 
 def create_dynamic_model(table_name, base=Base):
+
+    if not table_exists(table_name):
+        return
+
     class DynamicAnnotation(base):
         __tablename__ = table_name
         __table__ = Table(table_name, base.metadata, autoload_with=engine)

--- a/quickannotator/db/crud/annotation_class.py
+++ b/quickannotator/db/crud/annotation_class.py
@@ -2,6 +2,7 @@ import quickannotator.db.models as db_models
 from quickannotator.db import db_session
 import sqlalchemy
 from typing import List
+import quickannotator.constants as constants
 
 def get_annotation_class_by_id(annotation_class_id: int) -> db_models.AnnotationClass:
     return db_session.query(db_models.AnnotationClass).get(annotation_class_id)
@@ -54,3 +55,14 @@ def search_annotation_class_by_project_id(project_id: int):
         (db_models.AnnotationClass.project_id == project_id) | 
         (db_models.AnnotationClass.project_id == None)
     ).all()
+
+
+def insert_tissue_mask_class():
+    if not get_annotation_class_by_id(constants.MASK_CLASS_ID):
+        insert_annotation_class(
+            project_id=None, 
+            name=constants.MASK_CLASS_NAME, 
+            color=constants.ANNOTATION_CLASS_COLOR_PALETTES[constants.COLOR_PALETTE_NAME][constants.MASK_CLASS_COLOR_IDX], 
+            work_mag=constants.MASK_CLASS_WORK_TILESIZE, 
+            work_tilesize=constants.MASK_CLASS_WORK_MAG
+        )

--- a/quickannotator/db/crud/annotation_class.py
+++ b/quickannotator/db/crud/annotation_class.py
@@ -63,6 +63,6 @@ def insert_tissue_mask_class():
             project_id=None, 
             name=constants.MASK_CLASS_NAME, 
             color=constants.ANNOTATION_CLASS_COLOR_PALETTES[constants.COLOR_PALETTE_NAME][constants.MASK_CLASS_COLOR_IDX], 
-            work_mag=constants.MASK_CLASS_WORK_TILESIZE, 
-            work_tilesize=constants.MASK_CLASS_WORK_MAG
+            work_mag=constants.MASK_CLASS_WORK_MAG, 
+            work_tilesize=constants.MASK_CLASS_WORK_TILESIZE
         )

--- a/quickannotator/populate_db.ipynb
+++ b/quickannotator/populate_db.ipynb
@@ -21,7 +21,7 @@
     "from tqdm import tqdm\n",
     "import shapely\n",
     "from shapely.geometry import shape\n",
-    "from quickannotator.db.crud.annotation_class import insert_annotation_class\n",
+    "from quickannotator.db.crud.annotation_class import insert_annotation_class, insert_tissue_mask_class\n",
     "from quickannotator.db.crud.image import add_image_by_path, get_image_by_id\n",
     "from quickannotator.db.crud.project import add_project\n",
     "import quickannotator.constants as constants\n",
@@ -178,15 +178,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "colors = constants.ANNOTATION_CLASS_COLOR_PALETTES['default']\n",
     "\n",
     "with get_session() as db_session:\n",
-    "    insert_annotation_class(\n",
-    "                            project_id=None,\n",
-    "                            name=\"Tissue Mask\",\n",
-    "                            color=colors[0],\n",
-    "                            work_mag=1.25,\n",
-    "                            work_tilesize=2048)\n"
+    "    insert_tissue_mask_class()"
    ]
   },
   {


### PR DESCRIPTION
This push also seeds the database to now decouple QuickAnnotator from the `populate_db` notebook. 