### PR TITLE
Fix null check for currentProject in NewClassModal

### DIFF
--- a/quickannotator/client/src/components/newClassModal.tsx
+++ b/quickannotator/client/src/components/newClassModal.tsx
@@ -27,7 +27,7 @@ const NewClassModal: React.FC<NewClassModalProps> = (props: NewClassModalProps) 
     const methods = useForm<IFormInput>(); // Initialize useForm with type
 
     useEffect(() => {
-        if (!props.currentProject.id) return;
+        if (!props.currentProject) return;
         // Fetch suggested magnification options from the server
         fetchMagnifications().then((resp) => {
             if (resp.status !== 200) {


### PR DESCRIPTION
This PR resolves the following error observed during a usability study:
![image](https://github.com/user-attachments/assets/e6fc68ec-55c6-4b25-b083-7d5aee870d0a)

