### PR TITLE
Relax AnnotationClass db model constraint

### DIFF
--- a/quickannotator/db/models.py
+++ b/quickannotator/db/models.py
@@ -6,7 +6,7 @@ from sqlalchemy.sql import func
 from quickannotator.db import Base
 from sqlalchemy.orm import relationship
 import geojson
-from sqlalchemy import JSON, Boolean, Column, DateTime, Float, ForeignKey, Index, Integer, Text, func, ext
+from sqlalchemy import JSON, Boolean, Column, DateTime, Float, ForeignKey, Index, Integer, Text, UniqueConstraint, func, ext
 from ..constants import TileStatus
 from sqlalchemy import Enum
 from datetime import datetime
@@ -73,11 +73,15 @@ class AnnotationClass(Base):
     project_id = Column(Integer, ForeignKey('project.id'), nullable=True)
 
     # columns
-    name = Column(Text, nullable=False, unique=True)
+    name = Column(Text, nullable=False)
     color = Column(Text, nullable=False)
     work_mag = Column(Float, nullable=False)
     work_tilesize = Column(Integer, nullable=False)
     datetime = Column(DateTime, default=datetime.now)
+
+    __table_args__ = (
+        UniqueConstraint('project_id', 'name', name='uq_annotation_class_project_name'),
+    )
 
 
 class Tile(Base):


### PR DESCRIPTION
- Previously, the unique constraint on AnnotationClass names was too strict, preventing users from using the same annotation class name across different projects.
- Here we relax the constraint so that only AnnotationClass names within the same project must be unique (required to prevent ambiguity when uploading existing annotations)

If you git pull this commit and have an existing QuickAnnotator database, the change will not take effect unless you manually alter the database tables:
```bash
docker exec -it <postgres_container> psql -U admin -d qa_postgis_db \
  -c "ALTER TABLE annotation_class DROP CONSTRAINT annotation_class_name_key; \
      ALTER TABLE annotation_class ADD CONSTRAINT uq_annotation_class_project_name UNIQUE (project_id, name);"
```
> NOTE: This operation is safe because it is a strict relaxation of constraints. None of your existing data will violate the new constraint.
