### PR TITLE
Update models.py

### DIFF
--- a/quickannotator/db/models.py
+++ b/quickannotator/db/models.py
@@ -63,6 +63,10 @@ class Image(Base):
     # relationships
     notifications = relationship("Notification", backref='image', lazy=True)
 
+    __table_args__ = (
+        UniqueConstraint('project_id', 'name', name='uq_image_project_name'),
+    )
+
 
 class AnnotationClass(Base):
     __tablename__ = 'annotation_class'


### PR DESCRIPTION
Image names within a project should be unique.
- This prevents collisions when existing annotations are uploaded and QA internally matches annotations to images by name.
- It also prevents images from being uploaded twice by accident.

We should also consider implementing similar idempotent behavior for existing annotation uploads and tissue mask generation
1. Only allow existing annotations to be uploaded to an image containing no annotations for a given annotation class
2. Only allow tissue masks to be generated for images containing no tissue mask annotations